### PR TITLE
Bump django-rgd-3d, django-rgd-fmv, django-rgd-geometry and django-rgd-imagery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'gunicorn',
         'pylibmc>=1.5.1',
         # RGD
-        'django-rgd-3d==0.2.13',
+        'django-rgd-3d==0.2.15',
         'django-rgd-fmv==0.2.13',
         'django-rgd-geometry==0.2.13',
         'django-rgd-imagery==0.2.13',


### PR DESCRIPTION
Bumps [django-rgd-3d](https://github.com/ResonantGeoData/ResonantGeoData), [django-rgd-fmv](https://github.com/ResonantGeoData/ResonantGeoData), [django-rgd-geometry](https://github.com/ResonantGeoData/ResonantGeoData) and [django-rgd-imagery](https://github.com/ResonantGeoData/ResonantGeoData). These dependencies needed to be updated together.
Updates `django-rgd-3d` from 0.2.13 to 0.2.15
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/423129f21e1f9bda19952547971bd585f7ac4ca7"><code>423129f</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/1f17e1c57903e3e8be0f024b6ca5bcf8cd50632e"><code>1f17e1c</code></a> Pin django-rgd dep in subpackages (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/672">#672</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/a9e7294e4eb9958b9e3edb9ed9237f272a746f73"><code>a9e7294</code></a> Bump django-configurations (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/671">#671</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0ed6fbeddbfc074c5e2b0e636288a5bbdc2cb790"><code>0ed6fbe</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/d69eda7c06cc42ddce74e4f69493c2b620a454d2"><code>d69eda7</code></a> Python client: add method for downloading checksum files (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/649">#649</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/4661692078c416312a4a1983b139d15551dc3f2b"><code>4661692</code></a> Bump follow-redirects from 1.14.1 to 1.14.7 in /django-rgd-3d/vtkjs_viewer (#...</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/9a128c1fdb45e9ee9b5b72733c663dd75dadc75c"><code>9a128c1</code></a> Fix LICENSE</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/7aac4d58c8277e3782ce68273d8cfa3b7c6f354f"><code>7aac4d5</code></a> Fix tiles metadata bounds</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/c4b6fd04378e6a104370abd96cd01d37cef69f34"><code>c4b6fd0</code></a> Hotfix CRS (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/660">#660</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0f83782e776b0cffdf140612d089cb1d448563ae"><code>0f83782</code></a> Remove RGD_STAC_BROWSER_LIMIT (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/659">#659</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/ResonantGeoData/ResonantGeoData/compare/0.2.13...0.2.15">compare view</a></li>
</ul>
</details>
<br />

Updates `django-rgd-fmv` from 0.2.13 to 0.2.15
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/423129f21e1f9bda19952547971bd585f7ac4ca7"><code>423129f</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/1f17e1c57903e3e8be0f024b6ca5bcf8cd50632e"><code>1f17e1c</code></a> Pin django-rgd dep in subpackages (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/672">#672</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/a9e7294e4eb9958b9e3edb9ed9237f272a746f73"><code>a9e7294</code></a> Bump django-configurations (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/671">#671</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0ed6fbeddbfc074c5e2b0e636288a5bbdc2cb790"><code>0ed6fbe</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/d69eda7c06cc42ddce74e4f69493c2b620a454d2"><code>d69eda7</code></a> Python client: add method for downloading checksum files (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/649">#649</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/4661692078c416312a4a1983b139d15551dc3f2b"><code>4661692</code></a> Bump follow-redirects from 1.14.1 to 1.14.7 in /django-rgd-3d/vtkjs_viewer (#...</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/9a128c1fdb45e9ee9b5b72733c663dd75dadc75c"><code>9a128c1</code></a> Fix LICENSE</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/7aac4d58c8277e3782ce68273d8cfa3b7c6f354f"><code>7aac4d5</code></a> Fix tiles metadata bounds</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/c4b6fd04378e6a104370abd96cd01d37cef69f34"><code>c4b6fd0</code></a> Hotfix CRS (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/660">#660</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0f83782e776b0cffdf140612d089cb1d448563ae"><code>0f83782</code></a> Remove RGD_STAC_BROWSER_LIMIT (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/659">#659</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/ResonantGeoData/ResonantGeoData/compare/0.2.13...0.2.15">compare view</a></li>
</ul>
</details>
<br />

Updates `django-rgd-geometry` from 0.2.13 to 0.2.15
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/423129f21e1f9bda19952547971bd585f7ac4ca7"><code>423129f</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/1f17e1c57903e3e8be0f024b6ca5bcf8cd50632e"><code>1f17e1c</code></a> Pin django-rgd dep in subpackages (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/672">#672</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/a9e7294e4eb9958b9e3edb9ed9237f272a746f73"><code>a9e7294</code></a> Bump django-configurations (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/671">#671</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0ed6fbeddbfc074c5e2b0e636288a5bbdc2cb790"><code>0ed6fbe</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/d69eda7c06cc42ddce74e4f69493c2b620a454d2"><code>d69eda7</code></a> Python client: add method for downloading checksum files (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/649">#649</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/4661692078c416312a4a1983b139d15551dc3f2b"><code>4661692</code></a> Bump follow-redirects from 1.14.1 to 1.14.7 in /django-rgd-3d/vtkjs_viewer (#...</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/9a128c1fdb45e9ee9b5b72733c663dd75dadc75c"><code>9a128c1</code></a> Fix LICENSE</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/7aac4d58c8277e3782ce68273d8cfa3b7c6f354f"><code>7aac4d5</code></a> Fix tiles metadata bounds</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/c4b6fd04378e6a104370abd96cd01d37cef69f34"><code>c4b6fd0</code></a> Hotfix CRS (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/660">#660</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0f83782e776b0cffdf140612d089cb1d448563ae"><code>0f83782</code></a> Remove RGD_STAC_BROWSER_LIMIT (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/659">#659</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/ResonantGeoData/ResonantGeoData/compare/0.2.13...0.2.15">compare view</a></li>
</ul>
</details>
<br />

Updates `django-rgd-imagery` from 0.2.13 to 0.2.15
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/423129f21e1f9bda19952547971bd585f7ac4ca7"><code>423129f</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/1f17e1c57903e3e8be0f024b6ca5bcf8cd50632e"><code>1f17e1c</code></a> Pin django-rgd dep in subpackages (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/672">#672</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/a9e7294e4eb9958b9e3edb9ed9237f272a746f73"><code>a9e7294</code></a> Bump django-configurations (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/671">#671</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0ed6fbeddbfc074c5e2b0e636288a5bbdc2cb790"><code>0ed6fbe</code></a> Bump version</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/d69eda7c06cc42ddce74e4f69493c2b620a454d2"><code>d69eda7</code></a> Python client: add method for downloading checksum files (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/649">#649</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/4661692078c416312a4a1983b139d15551dc3f2b"><code>4661692</code></a> Bump follow-redirects from 1.14.1 to 1.14.7 in /django-rgd-3d/vtkjs_viewer (#...</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/9a128c1fdb45e9ee9b5b72733c663dd75dadc75c"><code>9a128c1</code></a> Fix LICENSE</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/7aac4d58c8277e3782ce68273d8cfa3b7c6f354f"><code>7aac4d5</code></a> Fix tiles metadata bounds</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/c4b6fd04378e6a104370abd96cd01d37cef69f34"><code>c4b6fd0</code></a> Hotfix CRS (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/660">#660</a>)</li>
<li><a href="https://github.com/ResonantGeoData/ResonantGeoData/commit/0f83782e776b0cffdf140612d089cb1d448563ae"><code>0f83782</code></a> Remove RGD_STAC_BROWSER_LIMIT (<a href="https://redirect.github.com/ResonantGeoData/ResonantGeoData/issues/659">#659</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/ResonantGeoData/ResonantGeoData/compare/0.2.13...0.2.15">compare view</a></li>
</ul>
</details>
<br />
